### PR TITLE
Remove cross-cluster PVC migration engine and SOPS from skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,12 +331,6 @@
                 right-sizing workloads across 11 distinct internal namespaces.
               </li>
               <li>
-                Authored asynchronous Kubernetes StatefulSet/PVC migration
-                tooling that scales source replicas, runs Rsync jobs, and
-                reconciles destination replicas to prevent split-brain during
-                cross-cluster data moves.
-              </li>
-              <li>
                 Automated ClickHouse upgrade blockers, Kafka Connect Azure
                 CosmosDB integration, Strimzi Kafka ACL deduplication, GitOps
                 egress firewall PRs, Vault snapshots, and safer Ansible


### PR DESCRIPTION
Removes the PVC migration bullet point, Tekton, and SOPS from skills listings.